### PR TITLE
feat: generic type support for attachable

### DIFF
--- a/src/main/java/io/foldright/inspectablewrappers/Attachable.java
+++ b/src/main/java/io/foldright/inspectablewrappers/Attachable.java
@@ -11,32 +11,34 @@ import javax.annotation.ParametersAreNonnullByDefault;
  * provide the attachment storage ability.
  * <p>
  * Retrieve the attachment from wrapper chain(wrapper instances implement interface {@link Wrapper})
- * by static method {@link Wrapper#getAttachment(Object, String)}.
+ * by static method {@link Wrapper#getAttachment(Object, Object)}.
  * <p>
  * Provide {@link io.foldright.inspectablewrappers.utils.AttachableDelegate AttachableDelegate} as a simple delegate implementation.
  *
+ * @param <Key> the key type, requirements depending on which storage you're using
+ * @param <Value> the value type you want to store
+ *
  * @author Jerry Lee (oldratlee at gmail dot com)
- * @see Wrapper#getAttachment(Object, String)
+ * @see Wrapper#getAttachment(Object, Object)
  * @see io.foldright.inspectablewrappers.utils.AttachableDelegate
  */
 @ParametersAreNonnullByDefault
 @ReturnValuesAreNonnullByDefault
-public interface Attachable {
+public interface Attachable<Key, Value> {
     /**
      * Sets an attachment.
      *
      * @param key   the attachment key
      * @param value the attachment value
      */
-    void setAttachment(String key, Object value);
+    void setAttachment(Key key, Value value);
 
     /**
      * Get the attachment of the given key.
      *
      * @param key the attachment key
-     * @param <V> the attachment value type
      * @return return the attachment value, or {@code null} if contains no attachment for the key
      */
     @Nullable
-    <V> V getAttachment(String key);
+    Value getAttachment(Key key);
 }

--- a/src/main/java/io/foldright/inspectablewrappers/Wrapper.java
+++ b/src/main/java/io/foldright/inspectablewrappers/Wrapper.java
@@ -62,7 +62,7 @@ public interface Wrapper<T> {
 
     /**
      * Retrieves the attachment of wrapper of given key on the wrapper chain
-     * by calling {@link Attachable#getAttachment(String)}.
+     * by calling {@link Attachable#getAttachment(Object)}.
      * <p>
      * The wrapper chain consists of wrapper itself, followed by the wrappers
      * obtained by repeatedly calling {@link #unwrap()}.
@@ -72,14 +72,16 @@ public interface Wrapper<T> {
      * @param wrapper wrapper instance
      * @param key     the attachment key
      * @param <W>     the type of instances that be wrapped
+     * @param <K>     the type of attachment key
+     * @param <V>     the type of attachment value
      */
     @Nullable
     @SuppressWarnings("unchecked")
-    static <W, V> V getAttachment(final W wrapper, final String key) {
+    static <W, K, V> V getAttachment(final W wrapper, final K key) {
         for (Object w = wrapper; w instanceof Wrapper; w = ((Wrapper<W>) w).unwrap()) {
             if (!(w instanceof Attachable)) continue;
 
-            V value = ((Attachable) w).getAttachment(key);
+            V value = ((Attachable<K, V>) w).getAttachment(key);
             if (value != null) return value;
         }
         return null;

--- a/src/main/java/io/foldright/inspectablewrappers/utils/AttachableDelegate.java
+++ b/src/main/java/io/foldright/inspectablewrappers/utils/AttachableDelegate.java
@@ -12,23 +12,31 @@ import java.util.concurrent.ConcurrentMap;
 /**
  * A simple {@link Attachable} delegate implementation.
  *
+ * <p>
+ * <strong>Note:</strong>
+ * </p>
+ * As we store the attachments in hash map. The implementation of the key type
+ * must meet the requirements of the hash map, which means that a stable hash
+ * code and the ability to compare equality using equals() must be implemented.
+ *
  * @author Jerry Lee (oldratlee at gmail dot com)
+ * @author Yang Fang (snoop dot fy at gmail dot com)
  * @see Attachable
  */
 @ParametersAreNonnullByDefault
 @ReturnValuesAreNonnullByDefault
-public class AttachableDelegate implements Attachable {
-    private final ConcurrentMap<String, Object> attachments = new ConcurrentHashMap<>();
+public class AttachableDelegate<K, V> implements Attachable<K, V> {
+    private final ConcurrentMap<Object, Object> attachments = new ConcurrentHashMap<>();
 
     @Override
-    public void setAttachment(String key, Object value) {
+    public void setAttachment(K key, V value) {
         attachments.put(key, value);
     }
 
     @Override
     @Nullable
     @SuppressWarnings("unchecked")
-    public <T> T getAttachment(String key) {
-        return (T) attachments.get(key);
+    public V getAttachment(K key) {
+        return (V) attachments.get(key);
     }
 }

--- a/src/test/java/io/foldright/demo/LazyExecutorWrapper.java
+++ b/src/test/java/io/foldright/demo/LazyExecutorWrapper.java
@@ -12,7 +12,7 @@ import java.util.concurrent.Executor;
 
 @ParametersAreNonnullByDefault
 @ReturnValuesAreNonnullByDefault
-public class LazyExecutorWrapper implements Executor, Wrapper<Executor>, Attachable {
+public class LazyExecutorWrapper implements Executor, Wrapper<Executor>, Attachable<String, String> {
     private final Executor executor;
 
     public LazyExecutorWrapper(Executor executor) {
@@ -40,16 +40,16 @@ public class LazyExecutorWrapper implements Executor, Wrapper<Executor>, Attacha
         return executor;
     }
 
-    private final Attachable attachable = new AttachableDelegate();
+    private final Attachable<String, String> attachable = new AttachableDelegate<>();
 
     @Override
-    public void setAttachment(String key, Object value) {
+    public void setAttachment(String key, String value) {
         attachable.setAttachment(key, value);
     }
 
     @Nullable
     @Override
-    public <V> V getAttachment(String key) {
+    public String getAttachment(String key) {
         return attachable.getAttachment(key);
     }
 }

--- a/src/test/java/io/foldright/inspectablewrappers/WrapperTest.kt
+++ b/src/test/java/io/foldright/inspectablewrappers/WrapperTest.kt
@@ -22,7 +22,7 @@ class WrapperTest : FunSpec({
         val value: String = Wrapper.getAttachment(chatty, "busy")!!
         value shouldBe "very very busy!"
 
-        Wrapper.getAttachment<Executor, String>(chatty, "not existed").shouldBeNull()
+        Wrapper.getAttachment<Executor, String, String>(chatty, "not existed").shouldBeNull()
     }
 })
 
@@ -36,7 +36,7 @@ class ChattyExecutorWrapper(private val executor: Executor) : Executor, Wrapper<
 }
 
 class LazyExecutorWrapper(private val executor: Executor) :
-        Executor, Wrapper<Executor>, Attachable by AttachableDelegate() {
+        Executor, Wrapper<Executor>, Attachable<String, String> by AttachableDelegate() {
     override fun execute(command: Runnable) {
         println("I'm lazy, sleep before work")
         sleep()


### PR DESCRIPTION
The attachable implementation uses String as key type. If someone selects the same string in the top layer, the value will be shaded in the lower layer.

Although we can isolate using the namespace of a string, it is not an absolute security guarantee. Adding generics does not impose a burden on using a string as the key type, but it should be noted that the current default implementation uses a hash map for storage, which requires the key to meet the requirements of the hash map for the key type.

Resolves: #4